### PR TITLE
Updates to the code so the module is runable again

### DIFF
--- a/TD_BRAIN_code/BRAIN_code/alphaPowerandiAPF.py
+++ b/TD_BRAIN_code/BRAIN_code/alphaPowerandiAPF.py
@@ -25,7 +25,7 @@ def computeFFT(data):
     from scipy.signal import hann
     hannwin = np.array(hann(data.shape[-1]))
     power = np.squeeze(np.mean(np.abs(np.fft.fft(data*hannwin))**2,axis=0))
-    freqs = np.linspace(0,varargs['fs']/2,np.int(len(power)/2)) #power1
+    freqs = np.linspace(0,varargs['fs']/2,np.int32(len(power)/2)) #power1
     return power[:len(freqs)], freqs
 
 
@@ -55,7 +55,7 @@ for f in files.selectedfiles:
     output['session'].append(sessid)
     output['conds'].append(f.rsplit('_')[-2])
     #read belonging tsvdat data
-    idx = np.where((tsvdat['subID']==np.int(sid)) & (tsvdat['sessID']==np.int(sessid)))[0][0]
+    idx = np.where((tsvdat['subID']==np.int32(sid)) & (tsvdat['sessID']==np.int32(sessid)))[0][0]
     output['age'].append(tsvdat['age'][idx])
     output['sex'].append(tsvdat['gender'][idx])
     output['power'] = np.vstack((output['power'],np.squeeze(computeFFT(chandata)[0])))

--- a/TD_BRAIN_code/BRAIN_code/autopreprocess_pipeline.py
+++ b/TD_BRAIN_code/BRAIN_code/autopreprocess_pipeline.py
@@ -9,8 +9,8 @@ copyright: Research Institute Brainclinics, Brainclinics Foundation, Nijmegen, t
 
 """
 
-from TD_BRAIN_code.autopreprocessing import dataset as ds
-from TD_BRAIN_code.inout import FilepathFinder as FF
+from BRAIN_code.autopreprocessing import dataset as ds
+from BRAIN_code.inout import FilepathFinder as FF
 import os
 from pathlib import Path
 import numpy as np
@@ -50,6 +50,9 @@ def autopreprocess_standard(varargsin, subject = None, startsubj =0):
 
     if not 'exclude' in varargsin:
         varargsin['exclude'] = []
+
+    if varargsin['condition']: # added because of unboundlocalerror
+        reqconds = varargsin['condition']
 
     rawreport = 'yes'
 

--- a/TD_BRAIN_code/BRAIN_code/autopreprocessing.py
+++ b/TD_BRAIN_code/BRAIN_code/autopreprocessing.py
@@ -343,12 +343,12 @@ class dataset:
             normal_cutoff = lpfreq / nyq
             b, a = butter(4, normal_cutoff, btype='lowpass', analog=False)
             filtEOG = filtfilt(b, a, EOG)
-            hilEOG  = hilbert(filtEOG.copy(), N=np.int(len(filtEOG)+
+            hilEOG  = hilbert(filtEOG.copy(), N=np.int32(len(filtEOG)+
                                              len(filtEOG)*0.20), axis = -1)
             hilbEOG = hilEOG[:filtEOG.shape[0]]
             amplenv = np.abs(hilbEOG)
 
-            boxdata = convolve(amplenv, boxcar(np.int(0.2*self.Fs)), mode ='same', method ='direct')
+            boxdata = convolve(amplenv, boxcar(np.int32(0.2*self.Fs)), mode ='same', method ='direct')
 
             '''.........................................................................'''
             ''' Regression NUMPY way'''
@@ -376,11 +376,11 @@ class dataset:
             if len(Atrl) > 0:
                 for i in range(Atrl.shape[0]):
                     if Atrl[i,0]==0:
-                        artsamples[0:Atrl[0,1]+np.int((Atrl[0,1]-0)*padding)]=1
+                        artsamples[0:Atrl[0,1]+np.int32((Atrl[0,1]-0)*padding)]=1
                     elif Atrl[i,1]==datapaddeddata.shape[1]:
-                        artsamples[Atrl[i,0]-np.int((Atrl[i,1]-Atrl[i,0])*padding):datapaddeddata.shape[1]]=1
+                        artsamples[Atrl[i,0]-np.int32((Atrl[i,1]-Atrl[i,0])*padding):datapaddeddata.shape[1]]=1
                     else:
-                        artsamples[Atrl[i,0]-np.int((Atrl[i,1]-Atrl[i,0])*padding):Atrl[i,1]+np.int((Atrl[i,1]-Atrl[i,0])*padding)]=1
+                        artsamples[Atrl[i,0]-np.int32((Atrl[i,1]-Atrl[i,0])*padding):Atrl[i,1]+np.int32((Atrl[i,1]-Atrl[i,0])*padding)]=1
 
             ''' Define the starts and endings of the collapsed EOG artifacts '''
             p = np.where(artsamples==1)[0]
@@ -458,7 +458,7 @@ class dataset:
         sos = butter(4, [high_pass, low_pass], btype='bandpass', analog=False, output = 'sos')
         filtEMG = sosfiltfilt(sos, self.data)
 
-        N=np.int(filtEMG.shape[1])#+filtEMG.shape[1]*0.10)
+        N=np.int32(filtEMG.shape[1])#+filtEMG.shape[1]*0.10)
         if N % 2 == 0:
             N=N
         else:
@@ -473,7 +473,7 @@ class dataset:
         hanndata = np.zeros((n_data_rows,self.data.shape[1]))
         ''' hanning smooth '''
         for r in range(n_data_rows):
-            hanndata[r,:] = convolve(amplenv[r,:], hann(np.int(0.5*self.Fs),sym=True), mode ='same')#, method ='direct')
+            hanndata[r,:] = convolve(amplenv[r,:], hann(np.int32(0.5*self.Fs),sym=True), mode ='same')#, method ='direct')
         ''' zvalue threshold '''
         Zdata = zscore(hanndata,axis=1)
         tmpEMGsamps = np.zeros((hanndata.shape[0],hanndata.shape[1]))
@@ -485,7 +485,7 @@ class dataset:
                 #introduce an absolute threshold to extract only EMG data that is evident?
                 didx = np.where(amplenv[r,sidx]>3)
                 tmpEMGsamps[r,sidx[didx]]=1
-                boxdata = convolve(tmpEMGsamps[r,:], boxcar(np.int(0.5*self.Fs)), mode ='same', method ='direct')
+                boxdata = convolve(tmpEMGsamps[r,:], boxcar(np.int32(0.5*self.Fs)), mode ='same', method ='direct')
                 inpEMGsamps[r,np.where(boxdata>0)]=1
 
         EMGtrl, EMGsamps = self._artifact_samps_trl(inpEMGsamps, padding,self.Fs, self.data[-1].shape[0])
@@ -575,7 +575,7 @@ class dataset:
         for r in range(n_data_rows):
             if ~np.isnan(self.data[r,0]):
                 for w in range(len(winstarts)):
-                    kurt[r,np.int(winstarts[w]):np.int(winends[w])] = kurtosis(self.data[r,np.int(winstarts[w]):np.int(winends[w])],fisher = True)
+                    kurt[r,np.int32(winstarts[w]):np.int32(winends[w])] = kurtosis(self.data[r,np.int32(winstarts[w]):np.int32(winends[w])],fisher = True)
 
                 if len(np.where(kurt[r,:]>threshold)[0]) > 0:
                     inpKURTsamps[r,np.where(kurt[r,:]>threshold)[0]]=1
@@ -631,7 +631,7 @@ class dataset:
         for r in range(n_data_rows):
             if ~np.isnan(self.data[r,0]):
                 for w in range(len(winstarts)):
-                    swing[r,np.int(winstarts[w]):np.int(winends[w])] = np.nanmax(self.data[r,np.int(winstarts[w]):np.int(winends[w])])-np.nanmin(self.data[r,np.int(winstarts[w]):np.int(winends[w])])
+                    swing[r,np.int32(winstarts[w]):np.int32(winends[w])] = np.nanmax(self.data[r,np.int32(winstarts[w]):np.int32(winends[w])])-np.nanmin(self.data[r,np.int32(winstarts[w]):np.int32(winends[w])])
                 if len(np.where(np.abs(swing[r,:])>threshold)[0]) > 0:
                     inpSWINGsamps[r,np.where(swing[r,:]>threshold)[0]]=1
 
@@ -660,7 +660,7 @@ class dataset:
         filtEB = sosfiltfilt(sos, self.data)
 #        filtpadding = filtEB.shape[1]*0.10
 
-        N=np.int(filtEB.shape[1]+filtEB.shape[1]*0.10)
+        N=np.int32(filtEB.shape[1]+filtEB.shape[1]*0.10)
         if N % 2 == 0:
             N=N
         else:
@@ -676,7 +676,7 @@ class dataset:
         hanndata = np.zeros((n_data_rows,self.data.shape[1]))
         ''' hanning smooth '''
         for r in range(n_data_rows):
-            hanndata[r,:] = convolve(amplenv[r,:], hann(np.int(1*self.Fs),sym=True), mode ='same')#, method ='direct')
+            hanndata[r,:] = convolve(amplenv[r,:], hann(np.int32(1*self.Fs),sym=True), mode ='same')#, method ='direct')
 
         ''' zvalue threshold '''
         Zdata = zscore(hanndata, axis=1)
@@ -794,7 +794,7 @@ class dataset:
         from scipy.fftpack import fft
         from scipy.signal import hann
 
-        hannwin = hann(np.int(self.data.shape[-1]))
+        hannwin = hann(np.int32(self.data.shape[-1]))
         power = np.abs(fft(self.data[:n_data_rows,:])*hannwin)**2
         freqs = np.linspace(0, self.Fs/2,int(len(power[0,:])/2))
         fid = [(np.where((freqs > 55) & (freqs < 95)))][0][0]
@@ -927,10 +927,10 @@ class dataset:
                     ''' select the segments around the artifacts (as much as possible) '''
                     ''' from the first sample to the beginning of the last artifact '''
                     t = 0
-                    trials=np.zeros((1,self.data.shape[1],np.int(self.Fs*epochlength)));marktrials = trials.copy();
+                    trials=np.zeros((1,self.data.shape[1],np.int32(self.Fs*epochlength)));marktrials = trials.copy();
                     trl = np.array([0,0],dtype=int)
                     for i in range(ARTtrl.shape[0]):
-                        if (ARTtrl[i,0]-t)>(np.int(epochlength*self.Fs)):
+                        if (ARTtrl[i,0]-t)>(np.int32(epochlength*self.Fs)):
                             tmp = self.data[:,t:ARTtrl[i,0]]
                             segs,segstrl = self._EEGsegmenting(np.asarray(tmp),epochlength)
                             trials = np.concatenate([trials,segs],axis=0)
@@ -1100,7 +1100,7 @@ class dataset:
 
                 segments = []
                 ticklocs = []
-                #ticks = np.arange(0,np.int(n_samples/self.Fs),np.around((np.int((n_samples/self.Fs))/10),decimals=1))
+                #ticks = np.arange(0,np.int32(n_samples/self.Fs),np.around((np.int32((n_samples/self.Fs))/10),decimals=1))
                 for i in range(n_rows):
                     segments.append(np.column_stack((t, data[seg,i,:])))
                     ticklocs.append(i * dr)
@@ -1466,12 +1466,12 @@ class dataset:
 
     def _EEGsegmenting(self,inp, trllength, fs=500, overlap=0):
 
-        epochlength = np.int(trllength*fs)
+        epochlength = np.int32(trllength*fs)
         stepsize = (1-overlap)*epochlength
 
         ''' define the size of the data '''
         n_totalsamples, n_samples, n_rows = inp.shape[1],epochlength, inp.shape[0]
-        n_trials = np.int(n_totalsamples/stepsize)
+        n_trials = np.int32(n_totalsamples/stepsize)
 
         trl = np.array([0,0],dtype=int)
         t = 0
@@ -1481,7 +1481,7 @@ class dataset:
 
         trl = trl[1:]
 
-        data = np.zeros((n_trials, n_rows, np.int(n_samples)))
+        data = np.zeros((n_trials, n_rows, np.int32(n_samples)))
         for i in range(n_trials):
             if trl[i,0] <= n_totalsamples-n_samples:
                 data[i,:,:]= inp[:,trl[i,0]:trl[i,1]]
@@ -1581,8 +1581,8 @@ class dataset:
             if len(upidxs)>len(downidxs):
                 downidxs = np.append(np.where(np.diff(inpdata)==-1)[0],totalsamps)
 
-            startidxs = upidxs-np.int(artpadding*Fs)
-            endidxs = downidxs+np.int(artpadding*Fs)
+            startidxs = upidxs-np.int32(artpadding*Fs)
+            endidxs = downidxs+np.int32(artpadding*Fs)
 
             tmpARTtrl = np.array([0,0],dtype=int)
             for k in range(len(startidxs)):

--- a/TD_BRAIN_code/BRAIN_code/interprocessing.py
+++ b/TD_BRAIN_code/BRAIN_code/interprocessing.py
@@ -182,10 +182,10 @@ class interdataset(object):
                     ''' select the segments around the artifacts (as much as possible) '''
                     ''' from the first sample to the beginning of the last artifact '''
                     t = 0
-                    trials=np.zeros((1,self.data.shape[1],np.int(self.Fs*epochlength)));marktrials = trials.copy();
+                    trials=np.zeros((1,self.data.shape[1],np.int32(self.Fs*epochlength)));marktrials = trials.copy();
                     trl = np.array([0,0],dtype=int)
                     for i in range(ARTtrl.shape[0]):
-                        if (ARTtrl[i,0]-t)>(np.int(epochlength*self.Fs)):
+                        if (ARTtrl[i,0]-t)>(np.int32(epochlength*self.Fs)):
                             tmp = self.data[:,:,t:ARTtrl[i,0]]
                             segs,segstrl = EEGsegmenting(np.asarray(tmp),epochlength)
                             trials = np.concatenate([trials,segs],axis=0)
@@ -368,7 +368,7 @@ class interdataset(object):
 
                 segments = []
                 ticklocs = []
-                #ticks = np.arange(0,np.int(n_samples/self.Fs),np.around((np.int((n_samples/self.Fs))/10),decimals=1))
+                #ticks = np.arange(0,np.int32(n_samples/self.Fs),np.around((np.int32((n_samples/self.Fs))/10),decimals=1))
                 for i in range(n_rows):
                     segments.append(np.column_stack((t, data[seg,i,:])))
                     ticklocs.append(i * dr)
@@ -730,12 +730,12 @@ class interdataset(object):
 
 def EEGsegmenting(inp, trllength, fs=500, overlap=0):
 
-    n_samples = np.int(trllength*fs)
+    n_samples = np.int32(trllength*fs)
     stepsize = (1-overlap)*n_samples
 
     ''' define the size of the data '''
     n_totalsamples, n_rows = inp.shape[-1], inp.shape[1]
-    n_trials = np.int(n_totalsamples/stepsize)
+    n_trials = np.int32(n_totalsamples/stepsize)
 
     trl = np.array([0,0],dtype=int)
     t = 0
@@ -745,7 +745,7 @@ def EEGsegmenting(inp, trllength, fs=500, overlap=0):
 
     trl = trl[1:]
 
-    data = np.zeros((n_trials, n_rows, np.int(n_samples)))
+    data = np.zeros((n_trials, n_rows, np.int32(n_samples)))
     for i in range(n_trials):
         if trl[i,0] <= n_totalsamples-n_samples:
             data[i,:,:]= inp[0,:,trl[i,0]:trl[i,1]]

--- a/TD_BRAIN_code/end2end_alphaPowerandiAPF.py
+++ b/TD_BRAIN_code/end2end_alphaPowerandiAPF.py
@@ -73,7 +73,7 @@ def end2end_alphaPowerandiAPF(varargs):
         from scipy.signal import hann
         hannwin = np.array(hann(data.shape[-1]))
         power = np.squeeze(np.mean(np.abs(np.fft.fft(data*hannwin))**2,axis=0))
-        freqs = np.linspace(0,Fs/2,np.int(len(power)/2)) #power1
+        freqs = np.linspace(0,Fs/2,np.int32(len(power)/2)) #power1
         return power[:len(freqs)], freqs
 
     output = {'IDcodes':['a'],
@@ -97,7 +97,7 @@ def end2end_alphaPowerandiAPF(varargs):
         output['conds'].append(f.rsplit('_')[-4])
         output['power'] = np.vstack((output['power'],np.squeeze(computeFFT(chandata)[0])))
         try:
-            idx = np.where((tsvdat['subID']==np.int(sid)) & (tsvdat['sessID']==np.int(sessid)))[0][0]
+            idx = np.where((tsvdat['subID']==np.int32(sid)) & (tsvdat['sessID']==np.int32(sessid)))[0][0]
             output['age'].append(tsvdat['age'][idx])
             output['sex'].append(tsvdat['gender'][idx])
         except:


### PR DESCRIPTION
1. np.int was deprecated, all occurrences of np.int were therefore changed to np.int32

2. Due to changes in the directory names and hierarchy, the autopreprocess_pipeline.py was trying to import from .py files in the wrong module/directory, resulting in a ModuleNotFoundError. The module name is now referenced to the right directory fixing the error.

3. The following error was raised when running end2end_alphaPowerandiAPF.py: UnboundLocalError: cannot access local variable 'reqconds' where it is not associated with a value. A code snippet was added in autopreprocess_pipeline.py, to make sure reqconds was set to varargsin['condition']